### PR TITLE
Change API to track deployments

### DIFF
--- a/armonic/common.py
+++ b/armonic/common.py
@@ -3,7 +3,6 @@ import sys
 import logging
 import logging.handlers
 import traceback
-import itertools
 import copy
 
 from armonic.utils import get_first_ip
@@ -96,15 +95,20 @@ def is_exposed(f):
     return getattr(f, 'exposed', False)
 
 
-def format_input_variables(*variables_values):
+def format_input_variables(requires=[]):
     """Translate ("//xpath/to/variable_name", "value")
        to ("//xpath/to/variable_name", {0: "value"})
     """
-    variables_values = list(itertools.chain(*variables_values))
+    if not requires:
+        return requires
+    variables_values = requires[0]
     for index, (variable_xpath, variable_values) in enumerate(variables_values):
         if not type(variable_values) == dict:
             variables_values[index] = (variable_xpath, {0: variable_values})
-    return variables_values
+    if len(requires) == 2:
+        return [variables_values, requires[1]]
+    elif len(requires) == 1:
+        return [variables_values]
 
 
 def load_lifecycles(lifecycle_dir=None, lifecycle_includes=[]):

--- a/armonic/lifecycle.py
+++ b/armonic/lifecycle.py
@@ -86,7 +86,7 @@ class StateFactory(type):
                 logger.debug("Registered %s in state %s" % (f._provide, state_class.__name__))
 
         return state_class
-        
+
 
 class State(XMLRessource):
     __metaclass__ = StateFactory
@@ -146,10 +146,14 @@ class State(XMLRessource):
     def _enter(self, requires=[]):
         """Check all state requires are satisfated and enter into State
 
-        :param requires: A list of of tuples (variable_xpath, variable_values)
-            variable_xpath is a full xpath
-            variable_values is dict of index=value
-        :type requires: list
+        :param requires: variable values to fill the requires::
+
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
+
+        :type requires: tuple of variable values and deployment info
         """
         self.provide_enter.fill(requires)
         self.provide_enter.validate()
@@ -488,12 +492,14 @@ class Lifecycle(XMLRessource):
 
         :param state: the target state
         :type state: state_name | :class:`State`
-        :param requires: variable values to fill the requires ::
+        :param requires: variable values to fill the requires::
 
-            ("//xpath/to/variable", {0: value}),
-            ("//xpath/to/variable", {0: value})
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
 
-        :type requires: list of tuples
+        :type requires: tuple of variable values and deployment info
         :param path_idx: the path to use when there is multiple paths
             to go to the target State
         :type path_idx: int
@@ -614,12 +620,14 @@ class Lifecycle(XMLRessource):
         :type state: state_name | :class:`State`
         :param provide_name: name of the provide
         :type provide_name: str
-        :param requires: variable values to fill the requires ::
+        :param requires: variable values to fill the requires::
 
-            ("//xpath/to/variable", {0: value}),
-            ("//xpath/to/variable", {0: value})
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
 
-        :type requires: list of tuples
+        :type requires: tuple of variable values and deployment info
 
         :rtype: provide result
         """
@@ -980,10 +988,14 @@ class LifecycleManager(XMLRessource):
 
         :param xpath: unique xpath of a state
         :type xpath: str
-        :param requires: list of of tuples (variable_xpath, variable_values):
-            variable_xpath is a full xpath
-            variable_values is dict of index=value
-        :type requires: list
+        :param requires: variable values to fill the requires::
+
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
+
+        :type requires: tuple of variable values and deployment info
 
         :rtype: None
         """
@@ -1067,12 +1079,14 @@ class LifecycleManager(XMLRessource):
 
         :param xpath: unique xpath of the provide to call
         :type xpath: str
-        :param requires: list of of tuples (variable_xpath, variable_values)::
+        :param requires: variable values to fill the requires::
 
-            ("//xpath/to/variable", {0: value}),
-            ("//xpath/to/variable", {0: value})
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
 
-        :type requires: list
+        :type requires: tuple of variable values and deployment info
 
         :return: list of validated provides to call
                  in order to call provide_xpath_uri
@@ -1105,9 +1119,14 @@ class LifecycleManager(XMLRessource):
 
         :param xpath: xpath of the provide to call
         :type xpath: str
-        :param requires: list of of tuples (variable_xpath, variable_values):
-            variable_xpath is a full xpath
-            variable_values is dict of index=value
+        :param requires: variable values to fill the requires::
+
+            ([
+                ("//xpath/to/variable", {0: value}),
+                ("//xpath/to/variable", {0: value})
+             ], {'source' : xpath, 'id': uuid})
+
+        :type requires: tuple of variable values and deployment info
 
         :return: provide_xpath_uri call result
         """

--- a/armonic/require.py
+++ b/armonic/require.py
@@ -286,16 +286,16 @@ class Require(XMLRessource, ExtraInfoMixin):
             raise
 
     def get_values(self):
-        """ FIXME This jsut return the first element"""
-        return [reduce(lambda a, x:
-                       dict(a.items() + {x.name: x.value}.items()),
-                       vs, {}) for vs in self._variables]
-
-    def get_default_values(self):
-        """ FIXME This jsut return the first element"""
-        return [reduce(lambda a, x:
-                       dict(a.items() + {x.name: x.default}.items()),
-                       vs, {}) for vs in self._variables]
+        variables_values = []
+        for variable in self._variables_skel:
+            variable_values = [variable.get_xpath(), {}]
+            for index, variables_set in enumerate(self.variables(all=True)):
+                for variable_in_set in variables_set:
+                    if variable_in_set.name == variable.name:
+                        variable_values[1][index] = variable_in_set.value
+                        break
+            variables_values.append(variable_values)
+        return variables_values
 
     def generate_args(self, dct={}):
         """Return a tuple. First element of tuple a dict of

--- a/armonic/tests/lfm_save_load_state_tests.py
+++ b/armonic/tests/lfm_save_load_state_tests.py
@@ -45,7 +45,7 @@ class TestLFMStateLoad(unittest.TestCase):
     def test_save_load(self):
         fh, state_file = tempfile.mkstemp()
         lfm = LifecycleManager(load_state=False, state_file=state_file)
-        lfm.state_goto("//LFMStateLoad/StateC", requires=[('//LFMStateLoad//bar/foo', 'test')])
+        lfm.state_goto("//LFMStateLoad/StateC", requires=[[('//LFMStateLoad//bar/foo', 'test')]])
         lfm.close()
         lfm = LifecycleManager(state_file=state_file)
         self.assertEqual(lfm.state_current('//LFMStateLoad')[0].name, "StateC")
@@ -53,8 +53,8 @@ class TestLFMStateLoad(unittest.TestCase):
     def test_metastate(self):
         fh, state_file = tempfile.mkstemp()
         with LifecycleManager(load_state=False, state_file=state_file) as lfm:
-            lfm.state_goto("//LFMStateLoad/StateE", requires=[('//LFMStateLoad//bar/foo', 'test1'),
-                                                              ('//LFMStateLoad//foo/bar', 'test2')])
+            lfm.state_goto("//LFMStateLoad/StateE", requires=[[('//LFMStateLoad//bar/foo', 'test1'),
+                                                               ('//LFMStateLoad//foo/bar', 'test2')]])
         lfm = LifecycleManager(state_file=state_file)
         self.assertEqual(lfm.state_current('//LFMStateLoad')[0].name, "StateE")
 

--- a/armonic/tests/metastate_tests.py
+++ b/armonic/tests/metastate_tests.py
@@ -33,13 +33,13 @@ class m2(MetaState):
 class TestProvide(unittest.TestCase):
 
     def test_simple(self):
-        """
-           -> b.m1 -> m1
-          /
-        a
-          \
-           -> b.m2 -> m2
-        """
+        #
+        #    -> b.m1 -> m1
+        #  /
+        # a
+        #  \
+        #    -> b.m2 -> m2
+        #
         class TestLifecycle(Lifecycle):
             initial_state = a()
             transitions = [

--- a/armonic/tests/provide_call_tests.py
+++ b/armonic/tests/provide_call_tests.py
@@ -47,26 +47,26 @@ class TestProvideCall(unittest.TestCase):
     def test_missing_provide_arg(self):
         with self.assertRaisesRegexp(ValidationError, "Provided values doesn't met provide requires"):
             self.lfm.provide_call("//ProvideCallLF//provide1",
-                                  requires=[("//ProvideCallLF//bar/foo", "test1")])
+                                  requires=[[("//ProvideCallLF//bar/foo", "test1")]])
 
     def test_missing_require(self):
         with self.assertRaisesRegexp(ValidationError, "Provided values doesn't met provide requires"):
             self.lfm.provide_call("//ProvideCallLF//provide1",
-                                  requires=[("//ProvideCallLF//foo1/bar", "test1")])
+                                  requires=[[("//ProvideCallLF//foo1/bar", "test1")]])
 
     def test_valid(self):
         self.assertEqual(self.lfm.provide_call("//ProvideCallLF//provide1",
-                                               requires=[("//ProvideCallLF//bar/foo", "test1"), ("//ProvideCallLF//foo1/bar", "test1")]), (1, 2))
+                                               requires=[[("//ProvideCallLF//bar/foo", "test1"), ("//ProvideCallLF//foo1/bar", "test1")]]), (1, 2))
 
     def test_provide_exception(self):
         with self.assertRaisesRegexp(ProvideError, 'some error'):
             self.lfm.provide_call("//ProvideCallLF//provide_error",
-                                  requires=[("//ProvideCallLF//bar/foo", "test1")])
+                                  requires=[[("//ProvideCallLF//bar/foo", "test1")]])
 
     def test_enter_exception(self):
         with self.assertRaisesRegexp(ProvideError, 'object has no attribute'):
             self.lfm.state_goto("//ProvideCallLF/StateC",
-                                requires=[("//ProvideCallLF//bar/foo", "test1")])
+                                requires=[[("//ProvideCallLF//bar/foo", "test1")]])
 
     def test_provide_clear(self):
         self.lfm.state_goto("//ProvideCallLF/StateA")
@@ -76,7 +76,7 @@ class TestProvideCall(unittest.TestCase):
         self.assertEqual(provide1.foo1.variables().bar.value, None)
         self.assertEqual(enter.bar.variables().foo.value, None)
         self.assertEqual(self.lfm.provide_call("//ProvideCallLF//provide1",
-                                               requires=[("//ProvideCallLF//bar/foo", "test1"), ("//ProvideCallLF//foo1/bar", "test1")]), (1, 2))
+                                               requires=[[("//ProvideCallLF//bar/foo", "test1"), ("//ProvideCallLF//foo1/bar", "test1")]]), (1, 2))
         self.assertEqual(provide1.foo1.variables().bar.value, None)
         self.assertEqual(enter.bar.variables().foo.value, None)
 

--- a/armonic/tests/provide_validation_tests.py
+++ b/armonic/tests/provide_validation_tests.py
@@ -70,99 +70,99 @@ class TestProvideValidation(unittest.TestCase):
 
     def test_no_require_provide(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1")]])
         self.assertFalse(validation['errors'])
 
     def test_missing_provide_arg(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide1",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1")]])
         self.assertTrue(validation['errors'])
         self.assertFalse(validation['requires'].enter.bar.variables().foo.error)
         self.assertEqual(validation['requires'].provide1.foo1.variables().bar.error, 'bar is required')
 
     def test_missing_require(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide1",
-                                                    requires=[("//ProvideValidationLF//foo1/bar", "test1")])
+                                                    requires=[[("//ProvideValidationLF//foo1/bar", "test1")]])
         self.assertTrue(validation['errors'])
         self.assertEqual(validation['requires'].enter.bar.variables().foo.error, 'foo is required')
         self.assertFalse(validation['requires'].provide1.foo1.variables().bar.error)
 
     def test_valid(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide1",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo1/bar", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo1/bar", "test1")]])
         self.assertEqual(validation['requires'].provide1.foo1.variables().bar.error, None)
         self.assertEqual(validation['requires'].enter.bar.variables().foo.error, None)
         self.assertFalse(validation['errors'])
 
     def test_multiple_variables(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide2",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo2/bar1", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo2/bar1", "test1")]])
         self.assertTrue(validation['errors'])
         self.assertEqual(validation['requires'].provide2.foo2.variables().bar2.error, 'bar2 is required')
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide2",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo2/bar2", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo2/bar2", "test1")]])
         self.assertTrue(validation['errors'])
         self.assertEqual(validation['requires'].provide2.foo2.variables().bar1.error, 'bar1 is required')
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide2",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo2/bar2", "test1"),
-                                                              ("//ProvideValidationLF//foo2/bar1", "test2")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo2/bar2", "test1"),
+                                                               ("//ProvideValidationLF//foo2/bar1", "test2")]])
         self.assertFalse(validation['errors'])
 
     def test_multiple_requires(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide3",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo3/bar1", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo3/bar1", "test1")]])
         self.assertTrue(validation['errors'])
         self.assertEqual(validation['requires'].provide3.bar3.variables().foo1.error, 'foo1 is required')
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide3",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo3/bar1", "test1"),
-                                                              ("//ProvideValidationLF//bar3/foo1", "test2")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo3/bar1", "test1"),
+                                                               ("//ProvideValidationLF//bar3/foo1", "test2")]])
         self.assertFalse(validation['errors'])
 
     def test_custom_validation(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide4",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo4/host4", "44")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo4/host4", "44")]])
         self.assertTrue(validation['errors'])
         self.assertIn('Incorrect Hostname', validation['requires'].provide4.foo4.variables().host4.error)
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide4",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo4/host4", "myhost33")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo4/host4", "myhost33")]])
         self.assertFalse(validation['errors'])
 
     def test_nargs_unlimited(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide5",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo5/bar5", {0: "test1", 1: "test2"})])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo5/bar5", {0: "test1", 1: "test2"})]])
         self.assertFalse(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide5",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo5/bar5", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo5/bar5", "test1")]])
         self.assertFalse(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide5",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1")]])
         self.assertFalse(validation['errors'])
 
     def test_nargs_fixed(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide6",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1")]])
         self.assertTrue(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide6",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo6/bar6", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo6/bar6", "test1")]])
         self.assertTrue(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide6",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo6/bar6", {0: "test1", 1: "test2"})])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo6/bar6", {0: "test1", 1: "test2"})]])
         self.assertFalse(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide6",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo6/bar6", {0: "test1", 1: "test2", 2: "test3"})])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo6/bar6", {0: "test1", 1: "test2", 2: "test3"})]])
         # "//ProvideValidationLF//foo6[3]/bar6" is ignored
         with self.assertRaises(DoesNotExist):
             validation['requires'].provide6.foo6.variables(2)
@@ -170,15 +170,15 @@ class TestProvideValidation(unittest.TestCase):
 
     def test_nargs_zero_or_one(self):
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide7",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1")]])
         self.assertFalse(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide7",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo7/bar7", "test1")])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo7/bar7", "test1")]])
         self.assertFalse(validation['errors'])
         validation = self.lfm.provide_call_validate("//ProvideValidationLF//provide7",
-                                                    requires=[("//ProvideValidationLF//bar/foo", "test1"),
-                                                              ("//ProvideValidationLF//foo7/bar7", {0: "test1", 1: "test2"})])
+                                                    requires=[[("//ProvideValidationLF//bar/foo", "test1"),
+                                                               ("//ProvideValidationLF//foo7/bar7", {0: "test1", 1: "test2"})]])
         with self.assertRaises(DoesNotExist):
             validation['requires'].provide7.foo7.variables(2)
         self.assertFalse(validation['errors'])
@@ -186,8 +186,8 @@ class TestProvideValidation(unittest.TestCase):
     def test_variable_path_ambigious(self):
         with self.assertRaises(XpathMultipleMatch):
             self.lfm.provide_call_validate("//ProvideValidationLF//provide8",
-                                           requires=[("//ProvideValidationLF//foo", "test1"),
-                                                     ("//ProvideValidationLF//bar", "test1")])
+                                           requires=[[("//ProvideValidationLF//foo", "test1"),
+                                                      ("//ProvideValidationLF//bar", "test1")]])
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/armonic/tests/require_fill_tests.py
+++ b/armonic/tests/require_fill_tests.py
@@ -1,0 +1,96 @@
+import unittest
+import logging
+from platform import uname
+
+from armonic.lifecycle import State, LifecycleManager, Lifecycle, Transition
+from armonic.require import Require
+from armonic.variable import VString
+
+
+class StateA(State):
+
+    @Require('require1', [VString('bar1'), VString('bar2')])
+    def provide1(self):
+        pass
+
+    @Require('require22', [VString('bar221'), VString('bar222')])
+    @Require('require21', [VString('bar211'), VString('bar212')])
+    def provide2(self):
+        pass
+
+    @Require('require3', [VString('bar3')], nargs="*")
+    def provide3(self):
+        pass
+
+
+class StateB(State):
+    pass
+
+
+class RequireFillFL(Lifecycle):
+    initial_state = StateA()
+    transitions = [Transition(StateA(), StateB())]
+
+
+class TestProvideValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.hostname = uname()[1]
+        self.lfm = LifecycleManager(load_state=False)
+        self.maxDiff = None
+
+    def test_fill_simple_require(self):
+        require = self.lfm.from_xpath('//RequireFillFL//require1', ret='require')
+        values = [
+            ('//RequireFillFL//require1/bar1', {0: 'test1'}),
+            ('//RequireFillFL//require1/bar2', {0: 'test2'})
+        ]
+        require.fill(values)
+        ret = [
+            ['/%s/RequireFillFL/StateA/provide1/require1/bar1' % self.hostname, {0: 'test1'}],
+            ['/%s/RequireFillFL/StateA/provide1/require1/bar2' % self.hostname, {0: 'test2'}]
+        ]
+        self.assertEqual(require.get_values(), ret)
+
+    def test_fill_muliple_requires(self):
+        provide = self.lfm.from_xpath('//RequireFillFL//provide2', ret='provide')
+        values = [
+            ('//RequireFillFL//require21/bar211', {0: 'test1'}),
+            ('//RequireFillFL//require22/bar221', {0: 'test2'})
+        ]
+        provide.fill(values)
+        ret = [
+            ['/%s/RequireFillFL/StateA/provide2/require21/bar211' % self.hostname, {0: 'test1'}],
+            ['/%s/RequireFillFL/StateA/provide2/require21/bar212' % self.hostname, {0: None}],
+            ['/%s/RequireFillFL/StateA/provide2/require22/bar221' % self.hostname, {0: 'test2'}],
+            ['/%s/RequireFillFL/StateA/provide2/require22/bar222' % self.hostname, {0: None}]
+        ]
+        self.assertEqual(provide.get_values(), ret)
+        values = [
+            ('//RequireFillFL//require21/bar212', {0: 'test11'}),
+            ('//RequireFillFL//require22/bar222', {0: 'test22'})
+        ]
+        provide.fill(values)
+        ret = [
+            ['/%s/RequireFillFL/StateA/provide2/require21/bar211' % self.hostname, {0: 'test1'}],
+            ['/%s/RequireFillFL/StateA/provide2/require21/bar212' % self.hostname, {0: 'test11'}],
+            ['/%s/RequireFillFL/StateA/provide2/require22/bar221' % self.hostname, {0: 'test2'}],
+            ['/%s/RequireFillFL/StateA/provide2/require22/bar222' % self.hostname, {0: 'test22'}]
+        ]
+        self.assertEqual(provide.get_values(), ret)
+
+    def test_fill_nargs(self):
+        provide = self.lfm.from_xpath('//RequireFillFL//provide3', ret='provide')
+        values = [
+            ('//RequireFillFL//require3/bar3', {0: 'test1', 1: 'test2', 2: 'test3'})
+        ]
+        provide.fill(values)
+        ret = [
+            ['/%s/RequireFillFL/StateA/provide3/require3/bar3' % self.hostname, {0: 'test1', 1: 'test2', 2: 'test3'}],
+        ]
+        self.assertEqual(provide.get_values(), ret)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/armonic/tests/require_fill_tests.py
+++ b/armonic/tests/require_fill_tests.py
@@ -54,40 +54,40 @@ class TestProvideValidation(unittest.TestCase):
 
     def test_fill_muliple_requires(self):
         provide = self.lfm.from_xpath('//RequireFillFL//provide2', ret='provide')
-        values = [
+        values = [[
             ('//RequireFillFL//require21/bar211', {0: 'test1'}),
             ('//RequireFillFL//require22/bar221', {0: 'test2'})
-        ]
+        ], {}]
         provide.fill(values)
-        ret = [
+        ret = [[
             ['/%s/RequireFillFL/StateA/provide2/require21/bar211' % self.hostname, {0: 'test1'}],
             ['/%s/RequireFillFL/StateA/provide2/require21/bar212' % self.hostname, {0: None}],
             ['/%s/RequireFillFL/StateA/provide2/require22/bar221' % self.hostname, {0: 'test2'}],
             ['/%s/RequireFillFL/StateA/provide2/require22/bar222' % self.hostname, {0: None}]
-        ]
+        ], {}]
         self.assertEqual(provide.get_values(), ret)
-        values = [
+        values = [[
             ('//RequireFillFL//require21/bar212', {0: 'test11'}),
             ('//RequireFillFL//require22/bar222', {0: 'test22'})
-        ]
+        ], {'xpath': 'test', 'id': 56}]
         provide.fill(values)
-        ret = [
+        ret = [[
             ['/%s/RequireFillFL/StateA/provide2/require21/bar211' % self.hostname, {0: 'test1'}],
             ['/%s/RequireFillFL/StateA/provide2/require21/bar212' % self.hostname, {0: 'test11'}],
             ['/%s/RequireFillFL/StateA/provide2/require22/bar221' % self.hostname, {0: 'test2'}],
             ['/%s/RequireFillFL/StateA/provide2/require22/bar222' % self.hostname, {0: 'test22'}]
-        ]
+        ], {'xpath': 'test', 'id': 56}]
         self.assertEqual(provide.get_values(), ret)
 
     def test_fill_nargs(self):
         provide = self.lfm.from_xpath('//RequireFillFL//provide3', ret='provide')
-        values = [
+        values = [[
             ('//RequireFillFL//require3/bar3', {0: 'test1', 1: 'test2', 2: 'test3'})
-        ]
+        ]]
         provide.fill(values)
-        ret = [
+        ret = [[
             ['/%s/RequireFillFL/StateA/provide3/require3/bar3' % self.hostname, {0: 'test1', 1: 'test2', 2: 'test3'}],
-        ]
+        ], {}]
         self.assertEqual(provide.get_values(), ret)
 
 

--- a/armonic/tests/state_paths_tests.py
+++ b/armonic/tests/state_paths_tests.py
@@ -48,9 +48,9 @@ class h(MetaState):
 class TestPathGeneration(unittest.TestCase):
 
     def test_simple_path(self):
-        """
-        a -> b -> c -> d
-        """
+        #
+        # a -> b -> c -> d
+        #
         class TestLifecycle(Lifecycle):
             initial_state = a()
             transitions = [
@@ -74,11 +74,11 @@ class TestPathGeneration(unittest.TestCase):
                          [])
 
     def test_multiple_paths(self):
-        """
-             b ------>
-        a ->           e -> f
-             c -> d ->
-        """
+        #
+        #      b ------>
+        # a ->           e -> f
+        #      c -> d ->
+        #
         class TestLifecycle(Lifecycle):
             initial_state = a()
             transitions = [
@@ -105,11 +105,11 @@ class TestPathGeneration(unittest.TestCase):
                          [[(f(), 'leave'), (e(), 'leave'), (b(), 'leave')]])
 
     def test_multiple_ends(self):
-        """
-        a -> b ->        -> f
-                  d -> e
-             c ->        -> g
-        """
+        #
+        # a -> b ->        -> f
+        #           d -> e
+        #      c ->        -> g
+        #
         class TestLifecycle(Lifecycle):
             initial_state = a()
             transitions = [
@@ -133,11 +133,11 @@ class TestPathGeneration(unittest.TestCase):
                          [])
 
     def test_metastates(self):
-        """
-             i (debian) ->
-        a ->               h (meta) -> g
-             j (mbs)    ->
-        """
+        #
+        #      i (debian) ->
+        # a ->               h (meta) -> g
+        #      j (mbs)    ->
+        #
         class TestLifecycle(Lifecycle):
             initial_state = a()
             transitions = [


### PR DESCRIPTION
- Add get_values() method on Require and Provide to serialize Requires objects
  in a primitive that can be used to fill Requires.
  (list of tuples (variable_xpath, variable_value)).
  
  Will be used to save the provide calls history and be able to reconstruct Requires
  on agent start from the history (running a check method with last requires
  for example)
- API changes for requires.
  
  From [(variable_xpath, variable_vaule), ...] we should now send
  [[(variable_xpath, variable_vaule), ...], {'source': xpath, ...}]
