### PR TITLE
Improve persistance API

### DIFF
--- a/armonic/persist.py
+++ b/armonic/persist.py
@@ -1,0 +1,76 @@
+import os
+import json
+import logging
+
+from armonic.utils import Singleton
+
+
+logger = logging.getLogger(__name__)
+
+
+class Persist(object):
+    __metaclass__ = Singleton
+
+    def __init__(self, load_state=False, save_state=False, state_path="/tmp/armonic_%s%s_state"):
+        self.load_state = load_state
+        self.save_state = save_state
+        self.state_path = state_path
+        self.ressources = []
+        logger.info("Persist configuration: load_state=%s, save_state=%s" % (load_state, save_state))
+
+    def register(self, ressource):
+        if ressource not in self.ressources:
+            self.ressources.append(ressource)
+            logger.debug("Registered %s for persistance" % ressource)
+
+    def save(self):
+        for ressource in self.ressources:
+            ressource._persist_save()
+
+
+class PersistRessource(object):
+    _persist = False
+    """Define if the ressource can be persistant or not"""
+
+    @property
+    def _persist_file(self):
+        return Persist().state_path % (self._xml_ressource_name(),
+                                             self.get_xpath().replace('/', '_'))
+
+    def _persist_register(self):
+        if self._persist and (Persist().save_state or Persist().load_state):
+            Persist().register(self)
+            self._persist_load()
+
+    def _persist_save(self, *args, **kwargs):
+        if Persist().save_state:
+            logger.debug("Saving %s state in %s..." % (self.name, self._persist_file))
+            with open(self._persist_file, 'w') as f:
+                json.dump(self._persist_primitive(), f)
+        elif os.path.exists(self._persist_file):
+            logger.debug("Removing %s state file %s..." % (self.name, self._persist_file))
+            os.unlink(self._persist_file)
+        return True
+
+    def _persist_primitive(self):
+        """Must return a primitive that can be serialized.
+
+        Must be implemented in subclass.
+        """
+        raise NotImplementedError()
+
+    def _persist_load(self):
+        if Persist().load_state and os.path.exists(self._persist_file):
+            logger.debug("Loading %s state from %s..." % (self, self._persist_file))
+            with open(self._persist_file) as f:
+                state = json.load(f)
+            return self._persist_load_primitive(state)
+        else:
+            return None
+
+    def _persist_load_primitive(self, state):
+        """Restore ressource state from state primitive.
+
+        Must be implemented in subclass.
+        """
+        raise NotImplementedError()

--- a/armonic/tests/lfm_save_load_state_tests.py
+++ b/armonic/tests/lfm_save_load_state_tests.py
@@ -4,6 +4,7 @@ import tempfile
 
 from armonic import State, LifecycleManager, Lifecycle, Transition, \
                     MetaState, Require
+from armonic.persist import Persist
 from armonic.variable import VString
 
 
@@ -42,20 +43,37 @@ class LFMStateLoad(Lifecycle):
 
 class TestLFMStateLoad(unittest.TestCase):
 
+    def setUp(self):
+        self.pconfig = Persist(save_state=True)
+
     def test_save_load(self):
-        fh, state_file = tempfile.mkstemp()
-        lfm = LifecycleManager(load_state=False, state_file=state_file)
+        fh, state_path = tempfile.mkstemp(suffix="_%s%s")
+        self.pconfig.load_state = False
+        self.pconfig.save_state = True
+        self.pconfig.state_path = state_path
+        lfm = LifecycleManager()
         lfm.state_goto("//LFMStateLoad/StateC", requires=[[('//LFMStateLoad//bar/foo', 'test')]])
-        lfm.close()
-        lfm = LifecycleManager(state_file=state_file)
+        self.pconfig.save()
+        self.pconfig.ressources = []
+        self.pconfig.load_state = True
+        self.pconfig.save_state = False
+        lfm = LifecycleManager()
         self.assertEqual(lfm.state_current('//LFMStateLoad')[0].name, "StateC")
 
     def test_metastate(self):
-        fh, state_file = tempfile.mkstemp()
-        with LifecycleManager(load_state=False, state_file=state_file) as lfm:
-            lfm.state_goto("//LFMStateLoad/StateE", requires=[[('//LFMStateLoad//bar/foo', 'test1'),
-                                                               ('//LFMStateLoad//foo/bar', 'test2')]])
-        lfm = LifecycleManager(state_file=state_file)
+        fh, state_path = tempfile.mkstemp(suffix="%s%s")
+        self.pconfig.load_state = False
+        self.pconfig.save_state = True
+        self.pconfig.state_path = state_path
+        lfm = LifecycleManager()
+        lfm.state_goto("//LFMStateLoad/StateE", requires=[[('//LFMStateLoad//bar/foo', 'test1'),
+                                                           ('//LFMStateLoad//foo/bar', 'test2')]])
+        self.pconfig.save()
+        self.pconfig.ressources = []
+        self.pconfig.load_state = True
+        self.pconfig.save_state = False
+        self.pconfig.save()
+        lfm = LifecycleManager()
         self.assertEqual(lfm.state_current('//LFMStateLoad')[0].name, "StateE")
 
 

--- a/armonic/tests/require_fill_tests.py
+++ b/armonic/tests/require_fill_tests.py
@@ -36,7 +36,7 @@ class TestProvideValidation(unittest.TestCase):
 
     def setUp(self):
         self.hostname = uname()[1]
-        self.lfm = LifecycleManager(load_state=False)
+        self.lfm = LifecycleManager()
         self.maxDiff = None
 
     def test_fill_simple_require(self):

--- a/armonic/utils.py
+++ b/armonic/utils.py
@@ -122,3 +122,15 @@ def get_subclasses(c):
     for d in list(subclasses):
         subclasses.extend(get_subclasses(d))
     return subclasses
+
+
+class Singleton(type):
+
+    def __init__(cls, name, bases, dict):
+        super(Singleton, cls).__init__(name, bases, dict)
+        cls.instance = None
+
+    def __call__(cls, *args, **kw):
+        if cls.instance is None:
+            cls.instance = super(Singleton, cls).__call__(*args, **kw)
+        return cls.instance

--- a/armonic/xml_register.py
+++ b/armonic/xml_register.py
@@ -1,8 +1,10 @@
 from lxml.etree import Element, SubElement, tostring, ElementTree, XPathEvalError, _Element
-
 import logging
-logger = logging.getLogger(__name__)
 
+from armonic.persist import PersistRessource
+
+
+logger = logging.getLogger(__name__)
 RESSOURCE_ATTR = "ressource"
 
 
@@ -22,7 +24,7 @@ class XpathInvalidExpression(Exception):
     pass
 
 
-class XMLRessource(object):
+class XMLRessource(PersistRessource):
     _xpath = None
     _xpath_relative = None
 
@@ -50,6 +52,11 @@ class XMLRessource(object):
         :rtype: a list of tuple (property_name, value)"""
         return []
 
+    def _xml_on_registration(self):
+        """Method run when the ressource is registered in the XML;
+        """
+        PersistRessource._persist_register(self)
+
     def get_xpath(self):
         return self._xpath
 
@@ -72,7 +79,7 @@ class XMLRegistery(object):
         return cls._instance
 
     def _xml_register(self, ressource, parent=None):
-        """ 
+        """
         :type ressource: XMLRessource
         :type parent: lxml.Element
         """
@@ -86,7 +93,7 @@ class XMLRegistery(object):
             xml_elt = SubElement(parent,
                                  ressource._xml_tag(),
                                  attrib=attributes)
-        
+
         ressource._xpath = self._xml_root_tree.getpath(xml_elt)
         try:
             ressource._xpath_relative = ressource._xpath.split("/", 2)[2]
@@ -112,6 +119,8 @@ class XMLRegistery(object):
                 properties_node.append(elt)
 
         self._xml_register_children(xml_elt, ressource)
+        logger.debug("Registered %s in XML registery" % ressource.__repr__())
+        ressource._xml_on_registration()
 
     def _xml_register_children(self, xml_elt, ressource):
         """Be careful, this removes children before adding them."""

--- a/bin/armonic-agent-socket
+++ b/bin/armonic-agent-socket
@@ -20,6 +20,7 @@ import struct
 import argparse
 
 from armonic.serialize import Serialize
+from armonic.persist import Persist
 import armonic.common
 
 PACKET_INFO_SIZE = 5
@@ -114,7 +115,7 @@ if __name__ == "__main__":
     parser.add_argument('--no-default-lifecycles', dest="no_default_lifecycles", action="store_true", default=False, help="Don't load provided lifecycles (default: %(default)s))")
     parser.add_argument('--no-load-state', '-l', dest="no_load_state", action="store_true", default=False, help='Load Armonic agent state on start (default: %(default)s))')
     parser.add_argument('--no-save-state', '-s', dest="no_save_state", action="store_true", default=False, help='Save Armonic agent state on exit (default: %(default)s))')
-    parser.add_argument('--state-path', dest="state_path", type=str, default="/tmp/armonic.state", help='Armonic agent state file path (default: %(default)s))')
+    parser.add_argument('--state-path', dest="state_path", type=str, default="/tmp/armonic_%s%s_state", help='Armonic state files paths (default: %(default)s))')
     args = parser.parse_args()
 
     logger = logging.getLogger()
@@ -146,12 +147,15 @@ if __name__ == "__main__":
     save_state = not args.no_save_state
     load_state = not args.no_load_state
 
-    with Serialize(load_state=load_state, save_state=save_state, state_file=args.state_path) as lfm:
-        print "Server listening on %s:%d" % (args.host, args.port)
-        server = MyTCPServer((args.host, args.port), MyTCPHandler)
-        # Activate the server; this will keep running until you
-        # interrupt the program with Ctrl-C
-        try:
-            server.serve_forever()
-        except KeyboardInterrupt:
-            print "Exiting."
+    persist = Persist(load_state, save_state, args.state_path)
+    lfm = Serialize()
+
+    print "Server listening on %s:%d" % (args.host, args.port)
+    server = MyTCPServer((args.host, args.port), MyTCPHandler)
+    # Activate the server; this will keep running until you
+    # interrupt the program with Ctrl-C
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print "Exiting."
+        persist.save()


### PR DESCRIPTION
Any XMLRessource can persist after the agent is shut down. Just set _persist
to True and implement two methods:

```
class Ressource(XMLRessource):
   _persist = True

    def _persist_primitive(self):
       """On stop return state primitive that will be saved."""
       return ...

    def _persist_load_primitive(self, primitive):
       """On start logic that restore ressource state from the
```

primitive."""
           ...

Running the agent with -s will _not_ save ressources states on exit. Running
the agent with -l will _not_ load ressources states on start.
